### PR TITLE
Fixed index out of range exception when parsing message type names.

### DIFF
--- a/src/ServiceBusMQ.NServiceBus/NServiceBusManagerBase.cs
+++ b/src/ServiceBusMQ.NServiceBus/NServiceBusManagerBase.cs
@@ -193,11 +193,15 @@ namespace ServiceBusMQ.NServiceBus {
 
         int start = 0;
         int end = type.IndexOf(',', start);
-
-        if( !includeNamespace ) {
-          start = type.LastIndexOf('.', end) + 1;
+        if( end < 0 ) {
+          r.Add(new MessageInfo(type));
         }
-        r.Add(new MessageInfo(type.Substring(start, end - start), type));
+        else {
+          if( !includeNamespace ) {
+            start = type.LastIndexOf('.', end) + 1;
+          }
+          r.Add(new MessageInfo(type.Substring(start, end - start), type));
+        }
       }
 
       return r.ToArray();


### PR DESCRIPTION
I think this bug only happens when the assembly name isn't strong-named. Crashes the program. Fixed!
